### PR TITLE
Correct project url on PIP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def main():
             'Topic :: Multimedia :: Graphics :: Capture :: Digital Camera',
         ],
         author="P. Junietz",
-        url="https://github.com/chilipp89/pibooth-qr-download",
+        url="https://github.com/chilipp89/pibooth-fire-remote",
         license='MIT',
         platforms=['unix', 'linux'],
         keywords=[


### PR DESCRIPTION
Current url is not working (as the plugin name was not the correct one)

If you include it you'll need to release a new version on pip.